### PR TITLE
Hotfix: fix page crash when creating new rehearsal

### DIFF
--- a/frontend/src/routes/RehearsalEditPage.jsx
+++ b/frontend/src/routes/RehearsalEditPage.jsx
@@ -147,15 +147,16 @@ class RehearsalEditPage extends Component {
    * @param {integer} ind Index of the rehearsal in the list 
    */
   renderRehearsal(rehearsal, ind){
-    let songs = rehearsal.songs.map((el)=>{
-      return {title: el.title, start: IntegerTime.fromDateString(el.pivot.start), end: IntegerTime.fromDateString(el.pivot.end)};
-    }).sort((a,b)=>IntegerTime.compare(a.start,b.start));
-
     const hasSongs = 'songs' in rehearsal && rehearsal.songs.length > 0;
+
+    let songs = hasSongs ? rehearsal.songs.map((el)=>{
+      return {title: el.title, start: IntegerTime.fromDateString(el.pivot.start), end: IntegerTime.fromDateString(el.pivot.end)};
+    }).sort((a,b)=>IntegerTime.compare(a.start,b.start)) : [];
+    
     const songText = hasSongs ? songs.map((el) =>{
       return (<p key={el.title}>{el.title} ({el.start.toReadableTime()} - {el.end.toReadableTime()}) </p>)
     }) : (<span>Nog geen</span>);
-    
+
     const start = new Date(rehearsal.start);
     const end = new Date(rehearsal.end);
 


### PR DESCRIPTION
Crashte omdat er niet werd gecheckt of er een bepaald veld op de rehearsal aanwezig was.